### PR TITLE
Extend glob based rules

### DIFF
--- a/accounts.example.yml
+++ b/accounts.example.yml
@@ -19,8 +19,8 @@ my_account:
     client_secret: t22
     cursive_font: true
     tag_position: "prepend" # "append", default: "append"
-    tag_count: 2 # default: 2
-    tags: # optional, app contains a default
+    random_tag_count: 2 # default: 2
+    random_tags: # optional, app contains a default
       - "#AIart"
       - "#AIイラスト"
       - "#AIArtwork"

--- a/src/clients/twitter.py
+++ b/src/clients/twitter.py
@@ -10,7 +10,11 @@ def decorate_caption(caption: str, config: TwitterPlatformConfig):
 
 
 def add_tags(caption: str, config: TwitterPlatformConfig):
-    combined_tags = " ".join(random.sample(config.tags, config.tag_count))
+    # Select random tags
+    random_tags = random.sample(config.random_tags, config.random_tag_count)
+    # Combine random tags and fixed tags
+    all_tags = random_tags + config.fixed_tags
+    combined_tags = " ".join(all_tags)
     if config.tag_position == "prepend":
         return f"{combined_tags} {caption}"
     return f"{caption} {combined_tags}"

--- a/src/models/account.py
+++ b/src/models/account.py
@@ -122,3 +122,4 @@ class Account:
         self.deviant_config.default_mature_classification = deviant_sub_config.get(
             "default_mature_classification", self.deviant_config.default_mature_classification
         )
+        self.deviant_config.featured = deviant_sub_config.get("featured", self.deviant_config.featured)

--- a/src/models/account.py
+++ b/src/models/account.py
@@ -25,10 +25,11 @@ class TwitterPlatformConfig(PlatformConfig):
     client_secret: str
     cursive_font: bool
     tag_position: str
-    tag_count: int
-    tags: List[str]
+    random_tag_count: int
+    random_tags: List[str]
+    fixed_tags: List[str]
 
-    DEFAULT_TAGS = [
+    DEFAULT_RANDOM_TAGS = [
         "#AIart",
         "#AIイラスト",
         "#AIArtwork",
@@ -49,8 +50,9 @@ class TwitterPlatformConfig(PlatformConfig):
         self.client_secret = config["client_secret"]
         self.cursive_font = config.get("cursive_font", False)
         self.tag_position = config.get("tag_position", "append")
-        self.tag_count = config.get("tag_count", 2)
-        self.tags = config.get("tags", self.DEFAULT_TAGS)
+        self.random_tag_count = config.get("random_tag_count", 2)
+        self.random_tags = config.get("random_tags", self.DEFAULT_RANDOM_TAGS)
+        self.fixed_tags = config.get("fixed_tags", [])
 
 
 class DeviantPlatformConfig(PlatformConfig):
@@ -117,9 +119,15 @@ class Account:
                 if self.deviant_config and "deviant" in sub_config:
                     self._update_deviant_config(sub_config["deviant"])
 
+                if self.twitter_config and "twitter" in sub_config:
+                    self._update_twitter_config(sub_config["twitter"])
+
     def _update_deviant_config(self, deviant_sub_config: Dict[str, any]):
         self.deviant_config.gallery_ids += deviant_sub_config.get("additional_gallery_ids", [])
         self.deviant_config.default_mature_classification = deviant_sub_config.get(
             "default_mature_classification", self.deviant_config.default_mature_classification
         )
         self.deviant_config.featured = deviant_sub_config.get("featured", self.deviant_config.featured)
+
+    def _update_twitter_config(self, twitter_sub_config: Dict[str, any]):
+        self.twitter_config.fixed_tags += twitter_sub_config.get("additional_fixed_tags", [])

--- a/src/schedule_image.py
+++ b/src/schedule_image.py
@@ -71,9 +71,10 @@ def execute(account: Account, mode: str):
         adjuster = ImageMetadataAdjuster(new_filepath)
         adjuster.add_tags(tag)
         adjuster.save()
-        return result
     else:
         print(f"Upload failed. Halted on {file}")
+
+    return result
 
 
 if __name__ == "__main__":

--- a/tests/clients/twitter_test.py
+++ b/tests/clients/twitter_test.py
@@ -90,12 +90,12 @@ class TestTwitterClient(unittest.TestCase):
             client.schedule("tests/fixtures/test.jpg", "some caption")
             self.mock_client.create_tweet.assert_called_once_with(text="#AIイラスト #AIArtworks some caption", media_ids=["1"])
 
-    def test_post_with_custom_tag_count(self):
+    def test_post_with_custom_random_tag_count(self):
         with (
             patch("tweepy.OAuthHandler", return_value=self.mock_oauth_handler),
             patch("tweepy.API", return_value=self.mock_api),
             patch("tweepy.Client", return_value=self.mock_client),
         ):
-            client = TwitterClient(get_fake_config({"twitter": {"tag_count": 3}}))
+            client = TwitterClient(get_fake_config({"twitter": {"random_tag_count": 3}}))
             client.schedule("tests/fixtures/test.jpg", "some caption")
             self.mock_client.create_tweet.assert_called_once_with(text="some caption #AIArtwork #AIイラスト #AIArtworks", media_ids=["1"])

--- a/tests/fixtures/accounts.yml
+++ b/tests/fixtures/accounts.yml
@@ -19,8 +19,8 @@ my_account:
     client_secret: t22
     cursive_font: true
     tag_position: "prepend" # "append", default: "append"
-    tag_count: 2 # default: 2
-    tags: # optional, app contains a default
+    random_tag_count: 2 # default: 2
+    random_tags: # optional, app contains a default
       - "#AIart"
       - "#AIArtwork"
       - "#AIArtCommunity"

--- a/tests/utils/account_test.py
+++ b/tests/utils/account_test.py
@@ -23,8 +23,8 @@ def sample_config(partial: Dict[str, any] = {}):
             "client_secret": "t22",
             "cursive_font": True,
             "tag_position": "prepend",
-            "tag_count": 2,
-            "tags": ["#AIart", "#AIArtwork", "#AIArtCommunity", "#AIArtGallery", "#AIArtworks"],
+            "random_tag_count": 2,
+            "random_tags": ["#AIart", "#AIArtwork", "#AIArtCommunity", "#AIArtGallery", "#AIArtworks"],
         },
         "deviant": {
             "client_id": 123,
@@ -34,13 +34,19 @@ def sample_config(partial: Dict[str, any] = {}):
             "featured": True,
         },
         "sub_configs": [
-            {"directory_path": "./tests/fixtures/test", "nsfw": True, "deviant": {"default_mature_classification": "test", "featured": False}},
+            {
+                "directory_path": "./tests/fixtures/test",
+                "nsfw": True,
+                "deviant": {"default_mature_classification": "test", "featured": False},
+                "twitter": {"additional_fixed_tags": ["#extra1", "#extra2"]},
+            },
             {
                 "directory_path": "./tests/fixtures/**/other",
                 "deviant": {
                     "additional_gallery_ids": ["123"],
                     "featured": True,
                 },
+                "twitter": {"additional_fixed_tags": ["#extra3"]},
             },
         ],
     }
@@ -110,6 +116,7 @@ class TestAccount(unittest.TestCase):
         result.set_config_for("./tests/fixtures/test/test.jpg")
         self.assertEqual(result.nsfw, True)
         self.assertEqual(result.deviant_config.featured, False)
+        self.assertEqual(result.twitter_config.fixed_tags, ["#extra1", "#extra2"])
         self.assertEqual(result.deviant_config.default_mature_classification, "test")
 
     def test_cascades_multiple_configs_on_multiple_matches(self):
@@ -121,3 +128,4 @@ class TestAccount(unittest.TestCase):
         self.assertEqual(result.deviant_config.featured, True)
         self.assertEqual(result.deviant_config.default_mature_classification, "test")
         self.assertEqual(result.deviant_config.gallery_ids, ["1", "123"])
+        self.assertEqual(result.twitter_config.fixed_tags, ["#extra1", "#extra2", "#extra3"])

--- a/tests/utils/account_test.py
+++ b/tests/utils/account_test.py
@@ -34,8 +34,14 @@ def sample_config(partial: Dict[str, any] = {}):
             "featured": True,
         },
         "sub_configs": [
-            {"directory_path": "./tests/fixtures/test", "nsfw": True, "deviant": {"default_mature_classification": "test"}},
-            {"directory_path": "./tests/fixtures/**/other", "deviant": {"additional_gallery_ids": ["123"]}},
+            {"directory_path": "./tests/fixtures/test", "nsfw": True, "deviant": {"default_mature_classification": "test", "featured": False}},
+            {
+                "directory_path": "./tests/fixtures/**/other",
+                "deviant": {
+                    "additional_gallery_ids": ["123"],
+                    "featured": True,
+                },
+            },
         ],
     }
     config.update(partial)
@@ -103,6 +109,7 @@ class TestAccount(unittest.TestCase):
         result = parse_account(config)
         result.set_config_for("./tests/fixtures/test/test.jpg")
         self.assertEqual(result.nsfw, True)
+        self.assertEqual(result.deviant_config.featured, False)
         self.assertEqual(result.deviant_config.default_mature_classification, "test")
 
     def test_cascades_multiple_configs_on_multiple_matches(self):
@@ -111,5 +118,6 @@ class TestAccount(unittest.TestCase):
         result = parse_account(config)
         result.set_config_for("./tests/fixtures/test/other/test.jpg")
         self.assertEqual(result.nsfw, True)
+        self.assertEqual(result.deviant_config.featured, True)
         self.assertEqual(result.deviant_config.default_mature_classification, "test")
         self.assertEqual(result.deviant_config.gallery_ids, ["1", "123"])

--- a/tests/utils/account_test.py
+++ b/tests/utils/account_test.py
@@ -13,7 +13,7 @@ def sample_config(partial: Dict[str, any] = {}):
         "extensions": ["jpg", "jpeg"],
         "platforms": ["Twitter", "Deviant"],
         "nsfw": False,
-        "twitter_config": {
+        "twitter": {
             "consumer_key": "t123",
             "consumer_secret": "t456",
             "bearer_token": "AAAAAAAAAAAAAAAAAAAAA",
@@ -26,7 +26,7 @@ def sample_config(partial: Dict[str, any] = {}):
             "tag_count": 2,
             "tags": ["#AIart", "#AIArtwork", "#AIArtCommunity", "#AIArtGallery", "#AIArtworks"],
         },
-        "deviant_config": {
+        "deviant": {
             "client_id": 123,
             "client_secret": 456,
             "default_mature_classification": "",


### PR DESCRIPTION
Extend globs:
- deviant: featured
- twitter: tags. Since existing tag definitions are used for random selection, i renamed those to "random_tags" (**breaking change**), while the overridable ones are called "fixed_tags" and are always added if defined.